### PR TITLE
Update SDK version to 2.3.2 and bump package to 0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.4] - 2025-07-30
+
+### Changed
+- Updated @covalenthq/client-sdk from 2.2.6 to 2.3.2
+  - Better error response standardization
+  - Executable pagination functions
+  - Various performance and stability improvements
+
 ## [0.0.3] - 2025-07-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@covalenthq/goldrush-mcp-server",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "GoldRush MCP Server for interacting with Covalent GoldRush API",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -68,7 +68,7 @@
     },
     "license": "MIT",
     "dependencies": {
-        "@covalenthq/client-sdk": "^2.2.6",
+        "@covalenthq/client-sdk": "^2.3.2",
         "@modelcontextprotocol/sdk": "^1.13.1",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",


### PR DESCRIPTION
## Summary
- Update @covalenthq/client-sdk from 2.2.6 to 2.3.2
- Bump package version to 0.0.4
- Add changelog entry documenting SDK improvements

## Changes
- Better error response standardization
- Executable pagination functions
- Various performance and stability improvements